### PR TITLE
Implement --spool-dir configuration option to specify spool directory

### DIFF
--- a/barman-wal-restore
+++ b/barman-wal-restore
@@ -40,7 +40,7 @@ except ImportError:
 DEFAULT_USER = 'barman'
 # TODO: Remove version from here and use setup.py's
 VERSION = '1.3'
-# TODO: make this generic
+# Default spool directory.
 SPOOL_DIR = '/var/tmp/barman-wal-restore'
 
 # The string_types list is used to identify strings
@@ -117,7 +117,7 @@ def spawn_additional_process(config, additional_files):
     """
     processes = []
     for wal_name in additional_files:
-        spool_file_name = os.path.join(SPOOL_DIR, wal_name)
+        spool_file_name = os.path.join(config.spool_dir, wal_name)
         try:
             # Spawn a process and write the output in the spool dir
             process = RemoteGetWal(config, wal_name, spool_file_name)
@@ -146,10 +146,10 @@ def peek_additional_files(config):
 
     # Make sure the SPOOL_DIR exists
     try:
-        if not os.path.exists(SPOOL_DIR):
-            os.mkdir(SPOOL_DIR)
+        if not os.path.exists(config.spool_dir):
+            os.mkdir(config.spool_dir)
     except EnvironmentError as e:
-        exit_with_error("Cannot create '%s' directory: %s" % (SPOOL_DIR, e))
+        exit_with_error("Cannot create '%s' directory: %s" % (config.spool_dir, e))
 
     # Retrieve the list of files from remote
     additional_files = execute_peek(config)
@@ -226,7 +226,7 @@ def try_deliver_from_spool(config, dest_file):
     :param argparse.Namespace config: the configuration from command line
     :param dest_file: The destination file object
     """
-    spool_file = os.path.join(SPOOL_DIR, config.wal_name)
+    spool_file = os.path.join(config.spool_dir, config.wal_name)
 
     # id the file is not present, give up
     if not os.path.exists(spool_file):
@@ -292,6 +292,12 @@ def parse_arguments(args=None):
         help="Specifies the number of files to peek and transfer "
              "in parallel. "
              "Defaults to 0 (disabled).",
+    )
+    parser.add_argument(
+        "--spool-dir", default=SPOOL_DIR,
+        metavar="SPOOL_DIR",
+        help="Specifies spool directory for WAL files. Defaults to "
+             "'{0}'.".format(SPOOL_DIR)
     )
     parser.add_argument(
         '-z', '--gzip',


### PR DESCRIPTION
Used to specify spool directory for WAL files. I need to have several Postgres slaves on one host, so spool directory can't be the same for them.

If the directive is not used spool directory will default to /var/tmp/barman-wal-restore